### PR TITLE
replace deprecated express send(code,body) calls

### DIFF
--- a/app.coffee
+++ b/app.coffee
@@ -84,7 +84,7 @@ if Settings.smokeTest
 
 app.get "/health_check", (req, res)->
 	res.contentType(resCacher?.setContentType)
-	res.send resCacher?.code, resCacher?.body
+	res.status(resCacher?.code).send(resCacher?.body)
 
 profiler = require "v8-profiler"
 app.get "/profile", (req, res) ->
@@ -101,7 +101,7 @@ app.get "/heapdump", (req, res)->
 
 app.use (error, req, res, next) ->
 	logger.error err: error, "server error"
-	res.send error?.statusCode || 500
+	res.sendStatus(error?.statusCode || 500)
 
 app.listen port = (Settings.internal?.clsi?.port or 3013), host = (Settings.internal?.clsi?.host or "localhost"), (error) ->
 	logger.info "CLSI starting up, listening on #{host}:#{port}"

--- a/app/coffee/CompileController.coffee
+++ b/app/coffee/CompileController.coffee
@@ -28,7 +28,7 @@ module.exports = CompileController =
 								status = "success"
 
 					timer.done()
-					res.send (code or 200), {
+					res.status(code or 200).send {
 						compile:
 							status: status
 							error:  error?.message or error
@@ -41,7 +41,7 @@ module.exports = CompileController =
 	clearCache: (req, res, next = (error) ->) ->
 		ProjectPersistenceManager.clearProject req.params.project_id, (error) ->
 			return next(error) if error?
-			res.send 204 # No content
+			res.sendStatus(204) # No content
 
 	syncFromCode: (req, res, next = (error) ->) ->
 		file   = req.query.file

--- a/test/unit/coffee/CompileControllerTests.coffee
+++ b/test/unit/coffee/CompileControllerTests.coffee
@@ -44,6 +44,7 @@ describe "CompileController", ->
 			}]
 			@RequestParser.parse = sinon.stub().callsArgWith(1, null, @request)
 			@ProjectPersistenceManager.markProjectAsJustAccessed = sinon.stub().callsArg(1)
+			@res.status = sinon.stub().returnsThis()
 			@res.send = sinon.stub()
 
 		describe "successfully", ->
@@ -67,8 +68,9 @@ describe "CompileController", ->
 					.should.equal true
 
 			it "should return the JSON response", ->
+				@res.status.calledWith(200).should.equal true
 				@res.send
-					.calledWith(200,
+					.calledWith(
 						compile:
 							status: "success"
 							error: null
@@ -85,8 +87,9 @@ describe "CompileController", ->
 				@CompileController.compile @req, @res
 		
 			it "should return the JSON response with the error", ->
+				@res.status.calledWith(500).should.equal true
 				@res.send
-					.calledWith(500,
+					.calledWith(
 						compile:
 							status: "error"
 							error:  @message
@@ -102,8 +105,9 @@ describe "CompileController", ->
 				@CompileController.compile @req, @res
 		
 			it "should return the JSON response with the timeout status", ->
+				@res.status.calledWith(200).should.equal true
 				@res.send
-					.calledWith(200,
+					.calledWith(
 						compile:
 							status: "timedout"
 							error: @message
@@ -117,8 +121,9 @@ describe "CompileController", ->
 				@CompileController.compile @req, @res
 		
 			it "should return the JSON response with the failure status", ->
+				@res.status.calledWith(200).should.equal true
 				@res.send
-					.calledWith(200,
+					.calledWith(
 						compile:
 							error: null
 							status: "failure"


### PR DESCRIPTION
Avoid warnings in the logs about calls to deprecated express functions

replace  res.send(code)  with res.sendStatus(code)
http://expressjs.com/4x/api.html#res.sendStatus

and res.send(code,body) with res.status(code).send(body)
http://expressjs.com/4x/api.html#res.status
http://expressjs.com/4x/api.html#res.send