### PR TITLE
add indexes to mysql db

### DIFF
--- a/app/coffee/db.coffee
+++ b/app/coffee/db.coffee
@@ -16,11 +16,20 @@ module.exports =
 		url: Sequelize.STRING
 		project_id: Sequelize.STRING
 		lastModified: Sequelize.DATE
+	}, {
+		indexes: [
+			{fields: ['url', 'project_id']},
+			{fields: ['project_id']}
+		]
 	})
 
 	Project: sequelize.define("Project", {
-		project_id: Sequelize.STRING
+		project_id: {type: Sequelize.STRING, primaryKey: true}
 		lastAccessed: Sequelize.DATE
+	}, {
+		indexes: [
+			{fields: ['lastAccessed']}
+		]
 	})
 
 	sync: () -> sequelize.sync()


### PR DESCRIPTION
Add indexes to mysql tables, note - needs upgrade to sequelize in another pull request for these to actually be created (with earlier versions the indexes aren't created, but the code still runs ok).