### PR TITLE
Set default project_cache_length_ms to 1 day

### DIFF
--- a/config/settings.defaults.coffee
+++ b/config/settings.defaults.coffee
@@ -44,5 +44,5 @@ module.exports =
 			url: "http://localhost:3013"
 			
 	smokeTest: false
-	project_cache_length_ms: 60 * 60 * 24
+	project_cache_length_ms: 1000 * 60 * 60 * 24
 	parallelFileDownloads:1


### PR DESCRIPTION
`project_cache_length_ms` was only `60*60*24 = 1.5 min` which is a little bit short. Default of one day seams more reasonable.