### PR TITLE
delete intermediate xdv files from xelatex

### DIFF
--- a/app/coffee/ResourceWriter.coffee
+++ b/app/coffee/ResourceWriter.coffee
@@ -48,7 +48,7 @@ module.exports = ResourceWriter =
 					should_delete = true
 					if path.match(/^output\./) or path.match(/\.aux$/) or path.match(/^cache\//) # knitr cache
 						should_delete = false
-					if path == "output.pdf" or path == "output.dvi" or path == "output.log"
+					if path == "output.pdf" or path == "output.dvi" or path == "output.log" or path == "output.xdv"
 						should_delete = true
 					if path == "output.tex" # created by TikzManager if present in output files
 						should_delete = true


### PR DESCRIPTION
avoid problem where user is compiling different main files and output.xdv is cached from the first one