### PR TITLE
Send a 404 if the project files have gone away when running synctex.

### DIFF
--- a/app/coffee/CompileManager.coffee
+++ b/app/coffee/CompileManager.coffee
@@ -13,6 +13,7 @@ fs = require("fs")
 fse = require "fs-extra"
 os = require("os")
 async = require "async"
+Errors = require './Errors'
 
 commandRunner = Settings.clsi?.commandRunner or "./CommandRunner"
 logger.info commandRunner:commandRunner, "selecting command runner for clsi"
@@ -206,11 +207,11 @@ module.exports = CompileManager =
 		synctexFile = Path.join(synctexDir, "output.synctex.gz")
 		fs.stat synctexDir, (error, stats) ->
 			if error?.code is 'ENOENT'
-				return callback(new Error("called synctex with no output directory"))
+				return callback(new Errors.NotFoundError("called synctex with no output directory"))
 			return callback(error) if error?
 			fs.stat synctexFile, (error, stats) ->
 				if error?.code is 'ENOENT'
-					return callback(new Error("called synctex with no output file"))
+					return callback(new Errors.NotFoundError("called synctex with no output file"))
 				return callback(error) if error?
 				return callback(new Error("not a file")) if not stats?.isFile()
 				callback()

--- a/app/coffee/Errors.coffee
+++ b/app/coffee/Errors.coffee
@@ -1,0 +1,10 @@
+NotFoundError = (message) ->
+	error = new Error(message)
+	error.name = "NotFoundError"
+	error.__proto__ = NotFoundError.prototype
+	return error
+NotFoundError.prototype.__proto__ = Error.prototype
+
+
+module.exports = Errors =
+	NotFoundError: NotFoundError


### PR DESCRIPTION
This is semantically nicer than the 500 response which used to be
produced in these circumstances.