### PR TITLE
Write files incrementally

### DIFF
--- a/app/coffee/CompileController.coffee
+++ b/app/coffee/CompileController.coffee
@@ -4,6 +4,7 @@ Settings = require "settings-sharelatex"
 Metrics = require "./Metrics"
 ProjectPersistenceManager = require "./ProjectPersistenceManager"
 logger = require "logger-sharelatex"
+Errors = require "./Errors"
 
 module.exports = CompileController =
 	compile: (req, res, next = (error) ->) ->
@@ -15,7 +16,7 @@ module.exports = CompileController =
 			ProjectPersistenceManager.markProjectAsJustAccessed request.project_id, (error) ->
 				return next(error) if error?
 				CompileManager.doCompile request, (error, outputFiles = []) ->
-					if error?.message is "invalid state"
+					if error instanceOf Errors.FilesOutOfSyncError
 						code = 409 # Http 409 Conflict
 						status = "retry"
 					else if error?.terminated

--- a/app/coffee/CompileController.coffee
+++ b/app/coffee/CompileController.coffee
@@ -15,7 +15,10 @@ module.exports = CompileController =
 			ProjectPersistenceManager.markProjectAsJustAccessed request.project_id, (error) ->
 				return next(error) if error?
 				CompileManager.doCompile request, (error, outputFiles = []) ->
-					if error?.terminated
+					if error?.message is "invalid state"
+						code = 409 # Http 409 Conflict
+						status = "retry"
+					else if error?.terminated
 						status = "terminated"
 					else if error?.validate
 						status = "validation-#{error.validate}"

--- a/app/coffee/CompileController.coffee
+++ b/app/coffee/CompileController.coffee
@@ -16,7 +16,7 @@ module.exports = CompileController =
 			ProjectPersistenceManager.markProjectAsJustAccessed request.project_id, (error) ->
 				return next(error) if error?
 				CompileManager.doCompile request, (error, outputFiles = []) ->
-					if error instanceOf Errors.FilesOutOfSyncError
+					if error instanceof Errors.FilesOutOfSyncError
 						code = 409 # Http 409 Conflict
 						status = "retry"
 					else if error?.terminated

--- a/app/coffee/CompileManager.coffee
+++ b/app/coffee/CompileManager.coffee
@@ -42,14 +42,12 @@ module.exports = CompileManager =
 			logger.log project_id: request.project_id, user_id: request.user_id, time_taken: Date.now() - timer.start, "written files to disk"
 			timer.done()
 
-			# FIXME - for incremental compiles we don't want to inject this multiple times
 			injectDraftModeIfRequired = (callback) ->
 				if request.draft
 					DraftModeManager.injectDraftMode Path.join(compileDir, request.rootResourcePath), callback
 				else
 					callback()
 
-			# FIXME - for incremental compiles we may need to update output.tex every time
 			createTikzFileIfRequired = (callback) ->
 				if TikzManager.needsOutputFile(request.rootResourcePath, resourceList)
 					TikzManager.injectOutputFile compileDir, request.rootResourcePath, callback

--- a/app/coffee/CompileManager.coffee
+++ b/app/coffee/CompileManager.coffee
@@ -32,9 +32,12 @@ module.exports = CompileManager =
 		timer = new Metrics.Timer("write-to-disk")
 		logger.log project_id: request.project_id, user_id: request.user_id, "syncing resources to disk"
 		ResourceWriter.syncResourcesToDisk request, compileDir, (error) ->
-			if error?
+			if error? and error instanceof Errors.FilesOutOfSyncError
+				logger.warn project_id: request.project_id, user_id: request.user_id, "files out of sync, please retry"
+				return callback(error)
+			else if error?
 				logger.err err:error, project_id: request.project_id, user_id: request.user_id, "error writing resources to disk"
-				return callback(error) 
+				return callback(error)
 			logger.log project_id: request.project_id, user_id: request.user_id, time_taken: Date.now() - timer.start, "written files to disk"
 			timer.done()
 			

--- a/app/coffee/CompileManager.coffee
+++ b/app/coffee/CompileManager.coffee
@@ -31,7 +31,7 @@ module.exports = CompileManager =
 
 		timer = new Metrics.Timer("write-to-disk")
 		logger.log project_id: request.project_id, user_id: request.user_id, "syncing resources to disk"
-		ResourceWriter.syncResourcesToDisk request.project_id, request.resources, compileDir, (error) ->
+		ResourceWriter.syncResourcesToDisk request, compileDir, (error) ->
 			if error?
 				logger.err err:error, project_id: request.project_id, user_id: request.user_id, "error writing resources to disk"
 				return callback(error) 

--- a/app/coffee/DraftModeManager.coffee
+++ b/app/coffee/DraftModeManager.coffee
@@ -5,6 +5,9 @@ module.exports = DraftModeManager =
 	injectDraftMode: (filename, callback = (error) ->) ->
 		fs.readFile filename, "utf8", (error, content) ->
 			return callback(error) if error?
+			# avoid adding draft mode more than once
+			if content?.indexOf("\\documentclass\[draft") >= 0
+				return callback()
 			modified_content = DraftModeManager._injectDraftOption content
 			logger.log {
 				content: content.slice(0,1024), # \documentclass is normally v near the top

--- a/app/coffee/Errors.coffee
+++ b/app/coffee/Errors.coffee
@@ -5,6 +5,13 @@ NotFoundError = (message) ->
 	return error
 NotFoundError.prototype.__proto__ = Error.prototype
 
+FilesOutOfSyncError = (message) ->
+	error = new Error(message)
+	error.name = "FilesOutOfSyncError"
+	error.__proto__ = FilesOutOfSyncError.prototype
+	return error
+FilesOutOfSyncError.prototype.__proto__ = Error.prototype
 
 module.exports = Errors =
 	NotFoundError: NotFoundError
+	FilesOutOfSyncError: FilesOutOfSyncError

--- a/app/coffee/RequestParser.coffee
+++ b/app/coffee/RequestParser.coffee
@@ -31,11 +31,11 @@ module.exports = RequestParser =
 			response.check = @_parseAttribute "check",
 				compile.options.check,
 				type: "string"
-			response.incremental = @_parseAttribute "incremental",
-				compile.options.incremental,
+			response.syncType = @_parseAttribute "syncType",
+				compile.options.syncType,
 				type: "string"
-			response.state = @_parseAttribute "state",
-				compile.options.state,
+			response.syncState = @_parseAttribute "syncState",
+				compile.options.syncState,
 				type: "string"
 
 			if response.timeout > RequestParser.MAX_TIMEOUT

--- a/app/coffee/RequestParser.coffee
+++ b/app/coffee/RequestParser.coffee
@@ -31,6 +31,12 @@ module.exports = RequestParser =
 			response.check = @_parseAttribute "check",
 				compile.options.check,
 				type: "string"
+			response.incremental = @_parseAttribute "incremental",
+				compile.options.incremental,
+				type: "string"
+			response.state = @_parseAttribute "state",
+				compile.options.state,
+				type: "string"
 
 			if response.timeout > RequestParser.MAX_TIMEOUT
 				response.timeout = RequestParser.MAX_TIMEOUT

--- a/app/coffee/RequestParser.coffee
+++ b/app/coffee/RequestParser.coffee
@@ -31,10 +31,24 @@ module.exports = RequestParser =
 			response.check = @_parseAttribute "check",
 				compile.options.check,
 				type: "string"
+
+			# The syncType specifies whether the request contains all
+			# resources (full) or only those resources to be updated
+			# in-place (incremental).
 			response.syncType = @_parseAttribute "syncType",
 				compile.options.syncType,
 				validValues: ["full", "incremental"]
 				type: "string"
+
+			# The syncState is an identifier passed in with the request
+			# which has the property that it changes when any resource is
+			# added, deleted, moved or renamed.
+			#
+			# on syncType full the syncState identifier is passed in and
+			# stored
+			#
+			# on syncType incremental the syncState identifier must match
+			# the stored value
 			response.syncState = @_parseAttribute "syncState",
 				compile.options.syncState,
 				type: "string"

--- a/app/coffee/RequestParser.coffee
+++ b/app/coffee/RequestParser.coffee
@@ -33,6 +33,7 @@ module.exports = RequestParser =
 				type: "string"
 			response.syncType = @_parseAttribute "syncType",
 				compile.options.syncType,
+				validValues: ["full", "incremental"]
 				type: "string"
 			response.syncState = @_parseAttribute "syncState",
 				compile.options.syncState,

--- a/app/coffee/ResourceListManager.coffee
+++ b/app/coffee/ResourceListManager.coffee
@@ -1,8 +1,8 @@
 Path = require "path"
 fs = require "fs"
-mkdirp = require "mkdirp"
 logger = require "logger-sharelatex"
 settings = require("settings-sharelatex")
+SafeReader = require "./SafeReader"
 
 module.exports = ResourceListManager =
 
@@ -18,7 +18,8 @@ module.exports = ResourceListManager =
 
 	loadResourceList: (basePath, callback = (error) ->) ->
 		resourceListFile = Path.join(basePath, @RESOURCE_LIST_FILE)
-		fs.readFile resourceListFile, (err, resourceList) ->
+		# limit file to 128K, compile directory is user accessible
+		SafeReader.readFile resourceListFile, 128*1024, 'utf8', (err, resourceList) ->
 			return callback(err) if err?
 			resources = ({path: path} for path in resourceList?.toString()?.split("\n") or [])
 			callback(null, resources)

--- a/app/coffee/ResourceListManager.coffee
+++ b/app/coffee/ResourceListManager.coffee
@@ -1,0 +1,24 @@
+Path = require "path"
+fs = require "fs"
+mkdirp = require "mkdirp"
+logger = require "logger-sharelatex"
+settings = require("settings-sharelatex")
+
+module.exports = ResourceListManager =
+
+	# This file is a list of the input files for the project, one per
+	# line, used to identify output files (i.e. files not on this list)
+	# when the incoming request is incremental.
+	RESOURCE_LIST_FILE: ".project-resource-list"
+
+	saveResourceList: (resources, basePath, callback = (error) ->) ->
+		resourceListFile = Path.join(basePath, @RESOURCE_LIST_FILE)
+		resourceList = (resource.path for resource in resources)
+		fs.writeFile resourceListFile, resourceList.join("\n"), callback
+
+	loadResourceList: (basePath, callback = (error) ->) ->
+		resourceListFile = Path.join(basePath, @RESOURCE_LIST_FILE)
+		fs.readFile resourceListFile, (err, resourceList) ->
+			return callback(err) if err?
+			resources = ({path: path} for path in resourceList?.toString()?.split("\n") or [])
+			callback(null, resources)

--- a/app/coffee/ResourceStateManager.coffee
+++ b/app/coffee/ResourceStateManager.coffee
@@ -1,9 +1,9 @@
 Path = require "path"
 fs = require "fs"
-mkdirp = require "mkdirp"
 logger = require "logger-sharelatex"
 settings = require("settings-sharelatex")
 Errors = require "./Errors"
+SafeReader = require "./SafeReader"
 
 module.exports = ResourceStateManager =
 
@@ -37,10 +37,9 @@ module.exports = ResourceStateManager =
 
 	checkProjectStateHashMatches: (state, basePath, callback) ->
 		stateFile = Path.join(basePath, @SYNC_STATE_FILE)
-		fs.readFile stateFile, {encoding:'ascii'}, (err, oldState) ->
-			if err? and err.code isnt 'ENOENT'
-				return callback(err)
-			else if state isnt oldState
+		SafeReader.readFile stateFile, 64, 'ascii', (err, oldState) ->
+			return callback(err) if err?
+			if state isnt oldState
 				return callback new Errors.FilesOutOfSyncError("invalid state for incremental update")
-			else if state is oldState
+			else
 				callback(null)

--- a/app/coffee/ResourceStateManager.coffee
+++ b/app/coffee/ResourceStateManager.coffee
@@ -1,0 +1,46 @@
+Path = require "path"
+fs = require "fs"
+mkdirp = require "mkdirp"
+logger = require "logger-sharelatex"
+settings = require("settings-sharelatex")
+Errors = require "./Errors"
+
+module.exports = ResourceStateManager =
+
+	# The sync state is an identifier which must match for an
+	# incremental update to be allowed.
+	#
+	# The initial value is passed in and stored on a full
+	# compile.
+	#
+	# Subsequent incremental compiles must come with the same value - if
+	# not they will be rejected with a 409 Conflict response.
+	#
+	# An incremental compile can only update existing files with new
+	# content.  The sync state identifier must change if any docs or
+	# files are moved, added, deleted or renamed.
+
+	SYNC_STATE_FILE: ".project-sync-state"
+
+	saveProjectStateHash: (state, basePath, callback) ->
+		stateFile = Path.join(basePath, @SYNC_STATE_FILE)
+		if not state? # remove the file if no state passed in
+			logger.log state:state, basePath:basePath, "clearing sync state"
+			fs.unlink stateFile, (err) ->
+				if err? and err.code isnt 'ENOENT'
+					return callback(err)
+				else
+					return callback()
+		else
+			logger.log state:state, basePath:basePath, "writing sync state"
+			fs.writeFile stateFile, state, {encoding: 'ascii'}, callback
+
+	checkProjectStateHashMatches: (state, basePath, callback) ->
+		stateFile = Path.join(basePath, @SYNC_STATE_FILE)
+		fs.readFile stateFile, {encoding:'ascii'}, (err, oldState) ->
+			if err? and err.code isnt 'ENOENT'
+				return callback(err)
+			else if state isnt oldState
+				return callback new Errors.FilesOutOfSyncError("invalid state for incremental update")
+			else if state is oldState
+				callback(null)

--- a/app/coffee/ResourceWriter.coffee
+++ b/app/coffee/ResourceWriter.coffee
@@ -13,23 +13,23 @@ parallelFileDownloads = settings.parallelFileDownloads or 1
 module.exports = ResourceWriter =
 
 	syncResourcesToDisk: (request, basePath, callback = (error) ->) ->
-		if request.incremental?
-			ResourceWriter.checkState request.incremental, basePath, (error, ok) ->
-				logger.log state: request.state, result:ok, "checked state on incremental request"
+		if request.syncType? is "incremental"
+			ResourceWriter.checkSyncState request.syncState, basePath, (error, ok) ->
+				logger.log syncState: request.syncState, result:ok, "checked state on incremental request"
 				return callback new Error("invalid state") if not ok
 				ResourceWriter.saveIncrementalResourcesToDisk request.project_id, request.resources, basePath, callback
 		else
 			@saveAllResourcesToDisk request.project_id, request.resources, basePath, (error) ->
 				return callback(error) if error?
-				ResourceWriter.storeState request.state, basePath, callback
+				ResourceWriter.storeSyncState request.syncState, basePath, callback
 
-	storeState: (state, basePath, callback) ->
-		logger.log state:state, basePath:basePath, "writing state"
-		fs.writeFile Path.join(basePath, ".resource-state"), state, {encoding: 'ascii'}, callback
+	storeSyncState: (state, basePath, callback) ->
+		logger.log state:state, basePath:basePath, "writing sync state"
+		fs.writeFile Path.join(basePath, ".resource-sync-state"), state, {encoding: 'ascii'}, callback
 
-	checkState: (state, basePath, callback) ->
-		fs.readFile Path.join(basePath, ".resource-state"), {encoding:'ascii'}, (err, oldState) ->
-			logger.log state:state, oldState: oldState, basePath:basePath, err:err, "checking state"
+	checkSyncState: (state, basePath, callback) ->
+		fs.readFile Path.join(basePath, ".resource-sync-state"), {encoding:'ascii'}, (err, oldState) ->
+			logger.log state:state, oldState: oldState, basePath:basePath, err:err, "checking sync state"
 			if state is oldState
 				return callback(null, true)
 			else

--- a/app/coffee/ResourceWriter.coffee
+++ b/app/coffee/ResourceWriter.coffee
@@ -25,11 +25,21 @@ module.exports = ResourceWriter =
 				ResourceWriter.storeSyncState request.syncState, basePath, callback
 
 	storeSyncState: (state, basePath, callback) ->
-		logger.log state:state, basePath:basePath, "writing sync state"
-		fs.writeFile Path.join(basePath, ".resource-sync-state"), state, {encoding: 'ascii'}, callback
+		stateFile = Path.join(basePath, ".resource-sync-state")
+		if not state? # remove the  file if no state passed in
+			logger.log state:state, basePath:basePath, "clearing sync state"
+			fs.unlink stateFile, (err) ->
+				if err? and err.code isnt 'ENOENT'
+					return callback(err)
+				else
+					return callback()
+		else
+			logger.log state:state, basePath:basePath, "writing sync state"
+			fs.writeFile stateFile, state, {encoding: 'ascii'}, callback
 
 	checkSyncState: (state, basePath, callback) ->
-		fs.readFile Path.join(basePath, ".resource-sync-state"), {encoding:'ascii'}, (err, oldState) ->
+		stateFile = Path.join(basePath, ".resource-sync-state")
+		fs.readFile stateFile, {encoding:'ascii'}, (err, oldState) ->
 			# ignore errors, return true if state matches, false otherwise (including errors)
 			return callback(null, if state is oldState then true else false)
 

--- a/app/coffee/ResourceWriter.coffee
+++ b/app/coffee/ResourceWriter.coffee
@@ -24,8 +24,23 @@ module.exports = ResourceWriter =
 				return callback(error) if error?
 				ResourceWriter.storeSyncState request.syncState, basePath, callback
 
+	# The sync state is an identifier which must match for an
+	# incremental update to be allowed.
+	#
+	# The initial value is passed in and stored on a full
+	# compile.
+	#
+	# Subsequent incremental compiles must come with the same value - if
+	# not they will be rejected with a 409 Conflict response.
+	#
+	# An incremental compile can only update existing files with new
+	# content.  The sync state identifier must change if any docs or
+	# files are moved, added, deleted or renamed.
+
+	SYNC_STATE_FILE: ".project-sync-state"
+
 	storeSyncState: (state, basePath, callback) ->
-		stateFile = Path.join(basePath, ".resource-sync-state")
+		stateFile = Path.join(basePath, @SYNC_STATE_FILE)
 		if not state? # remove the  file if no state passed in
 			logger.log state:state, basePath:basePath, "clearing sync state"
 			fs.unlink stateFile, (err) ->
@@ -38,10 +53,13 @@ module.exports = ResourceWriter =
 			fs.writeFile stateFile, state, {encoding: 'ascii'}, callback
 
 	checkSyncState: (state, basePath, callback) ->
-		stateFile = Path.join(basePath, ".resource-sync-state")
+		stateFile = Path.join(basePath, @SYNC_STATE_FILE)
 		fs.readFile stateFile, {encoding:'ascii'}, (err, oldState) ->
-			# ignore errors, return true if state matches, false otherwise (including errors)
-			return callback(null, if state is oldState then true else false)
+			if err? and err.code isnt 'ENOENT'
+				return callback(err)
+			else
+				# return true if state matches, false otherwise (including file not existing)
+				callback(null, if state is oldState then true else false)
 
 	saveIncrementalResourcesToDisk: (project_id, resources, basePath, callback = (error) ->) ->
 		@_createDirectory basePath, (error) =>

--- a/app/coffee/ResourceWriter.coffee
+++ b/app/coffee/ResourceWriter.coffee
@@ -53,7 +53,7 @@ module.exports = ResourceWriter =
 
 	storeSyncState: (state, basePath, callback) ->
 		stateFile = Path.join(basePath, @SYNC_STATE_FILE)
-		if not state? # remove the  file if no state passed in
+		if not state? # remove the file if no state passed in
 			logger.log state:state, basePath:basePath, "clearing sync state"
 			fs.unlink stateFile, (err) ->
 				if err? and err.code isnt 'ENOENT'

--- a/app/coffee/ResourceWriter.coffee
+++ b/app/coffee/ResourceWriter.coffee
@@ -5,6 +5,7 @@ async = require "async"
 mkdirp = require "mkdirp"
 OutputFileFinder = require "./OutputFileFinder"
 Metrics = require "./Metrics"
+Errors = require "./Errors"
 logger = require "logger-sharelatex"
 settings = require("settings-sharelatex")
 
@@ -16,7 +17,7 @@ module.exports = ResourceWriter =
 		if request.syncType? is "incremental"
 			ResourceWriter.checkSyncState request.syncState, basePath, (error, ok) ->
 				logger.log syncState: request.syncState, result:ok, "checked state on incremental request"
-				return callback new Error("invalid state") if not ok
+				return callback new Errors.FilesOutOfSyncError("invalid state for incremental update") if not ok
 				ResourceWriter.saveIncrementalResourcesToDisk request.project_id, request.resources, basePath, callback
 		else
 			@saveAllResourcesToDisk request.project_id, request.resources, basePath, (error) ->

--- a/app/coffee/SafeReader.coffee
+++ b/app/coffee/SafeReader.coffee
@@ -1,0 +1,24 @@
+fs = require "fs"
+
+module.exports = SafeReader =
+
+	# safely read up to size bytes from a file and return result as a
+	# string
+
+	readFile: (file, size, encoding, callback = (error, result) ->) ->
+		fs.open file, 'r', (err, fd) ->
+			return callback() if err? and  err.code is 'ENOENT'
+			return callback(err) if err?
+
+			# safely return always closing the file
+			callbackWithClose = (err, result) ->
+				fs.close fd, (err1) ->
+					return callback(err) if err?
+					return callback(err1) if err1?
+					callback(null, result)
+
+			buff = new Buffer(size, 0) # fill with zeros
+			fs.read fd, buff, 0, buff.length, 0, (err, bytesRead, buffer) ->
+				return callbackWithClose(err) if err?
+				result = buffer.toString(encoding, 0, bytesRead)
+				callbackWithClose(null, result)

--- a/test/unit/coffee/CompileManagerTests.coffee
+++ b/test/unit/coffee/CompileManagerTests.coffee
@@ -51,7 +51,7 @@ describe "CompileManager", ->
 			@env = {}
 			@Settings.compileDir = "compiles"
 			@compileDir = "#{@Settings.path.compilesDir}/#{@project_id}-#{@user_id}"
-			@ResourceWriter.syncResourcesToDisk = sinon.stub().callsArg(2)
+			@ResourceWriter.syncResourcesToDisk = sinon.stub().callsArgWith(2, null, @resources)
 			@LatexRunner.runLatex = sinon.stub().callsArg(2)
 			@OutputFileFinder.findOutputFiles = sinon.stub().callsArgWith(2, null, @output_files)
 			@OutputCacheManager.saveOutputFiles = sinon.stub().callsArgWith(2, null, @build_files)

--- a/test/unit/coffee/CompileManagerTests.coffee
+++ b/test/unit/coffee/CompileManagerTests.coffee
@@ -51,7 +51,7 @@ describe "CompileManager", ->
 			@env = {}
 			@Settings.compileDir = "compiles"
 			@compileDir = "#{@Settings.path.compilesDir}/#{@project_id}-#{@user_id}"
-			@ResourceWriter.syncResourcesToDisk = sinon.stub().callsArg(3)
+			@ResourceWriter.syncResourcesToDisk = sinon.stub().callsArg(2)
 			@LatexRunner.runLatex = sinon.stub().callsArg(2)
 			@OutputFileFinder.findOutputFiles = sinon.stub().callsArgWith(2, null, @output_files)
 			@OutputCacheManager.saveOutputFiles = sinon.stub().callsArgWith(2, null, @build_files)
@@ -64,7 +64,7 @@ describe "CompileManager", ->
 
 			it "should write the resources to disk", ->
 				@ResourceWriter.syncResourcesToDisk
-					.calledWith(@project_id, @resources, @compileDir)
+					.calledWith(@request, @compileDir)
 					.should.equal true
 
 			it "should run LaTeX", ->

--- a/test/unit/coffee/RequestParserTests.coffee
+++ b/test/unit/coffee/RequestParserTests.coffee
@@ -242,3 +242,13 @@ describe "RequestParser", ->
 		it "should return an error", ->
 			@callback.calledWith("relative path in root resource")
 				.should.equal true
+
+	describe "with an unknown syncType", ->
+		beforeEach ->
+			@validRequest.compile.options.syncType = "unexpected"
+			@RequestParser.parse @validRequest, @callback
+			@data = @callback.args[0][1]
+
+		it "should return an error", ->
+			@callback.calledWith("syncType attribute should be one of: full, incremental")
+				.should.equal true

--- a/test/unit/coffee/ResourceWriterTests.coffee
+++ b/test/unit/coffee/ResourceWriterTests.coffee
@@ -7,7 +7,9 @@ path = require "path"
 describe "ResourceWriter", ->
 	beforeEach ->
 		@ResourceWriter = SandboxedModule.require modulePath, requires:
-			"fs": @fs = { mkdir: sinon.stub().callsArg(1) }
+			"fs": @fs =
+				mkdir: sinon.stub().callsArg(1)
+				unlink: sinon.stub().callsArg(1)
 			"wrench": @wrench = {}
 			"./UrlCache" : @UrlCache = {}
 			"mkdirp" : @mkdirp = sinon.stub().callsArg(1)

--- a/test/unit/coffee/ResourceWriterTests.coffee
+++ b/test/unit/coffee/ResourceWriterTests.coffee
@@ -29,7 +29,9 @@ describe "ResourceWriter", ->
 			]
 			@ResourceWriter._writeResourceToDisk = sinon.stub().callsArg(3)
 			@ResourceWriter._removeExtraneousFiles = sinon.stub().callsArg(2)
-			@ResourceWriter.syncResourcesToDisk(@project_id, @resources, @basePath, @callback)
+			@ResourceWriter.checkSyncState = sinon.stub().callsArg(2)
+			@ResourceWriter.storeSyncState = sinon.stub().callsArg(2)
+			@ResourceWriter.syncResourcesToDisk({project_id: @project_id, resources: @resources}, @basePath, @callback)
 
 		it "should remove old files", ->
 			@ResourceWriter._removeExtraneousFiles

--- a/test/unit/coffee/ResourceWriterTests.coffee
+++ b/test/unit/coffee/ResourceWriterTests.coffee
@@ -10,6 +10,7 @@ describe "ResourceWriter", ->
 			"fs": @fs =
 				mkdir: sinon.stub().callsArg(1)
 				unlink: sinon.stub().callsArg(1)
+			"./ResourceListManager": @ResourceListManager = {}
 			"wrench": @wrench = {}
 			"./UrlCache" : @UrlCache = {}
 			"mkdirp" : @mkdirp = sinon.stub().callsArg(1)
@@ -33,6 +34,8 @@ describe "ResourceWriter", ->
 			@ResourceWriter._removeExtraneousFiles = sinon.stub().callsArg(2)
 			@ResourceWriter.checkSyncState = sinon.stub().callsArg(2)
 			@ResourceWriter.storeSyncState = sinon.stub().callsArg(2)
+			@ResourceListManager.saveResourceList = sinon.stub().callsArg(2)
+			@ResourceListManager.loadResourceList = sinon.stub().callsArg(1)
 			@ResourceWriter.syncResourcesToDisk({project_id: @project_id, resources: @resources}, @basePath, @callback)
 
 		it "should remove old files", ->

--- a/test/unit/coffee/ResourceWriterTests.coffee
+++ b/test/unit/coffee/ResourceWriterTests.coffee
@@ -54,7 +54,6 @@ describe "ResourceWriter", ->
 					.should.equal true
 
 		it "should store the sync state", ->
-			console.log "CHECKING", @syncState, @basePath
 			@ResourceWriter.storeSyncState
 				.calledWith(@syncState, @basePath)
 				.should.equal true
@@ -77,7 +76,7 @@ describe "ResourceWriter", ->
 			@ResourceWriter.checkSyncState = sinon.stub().callsArgWith(2, null, true)
 			@ResourceWriter.storeSyncState = sinon.stub().callsArg(2)
 			@ResourceListManager.saveResourceList = sinon.stub().callsArg(2)
-			@ResourceListManager.loadResourceList = sinon.stub().callsArg(1)
+			@ResourceListManager.loadResourceList = sinon.stub().callsArgWith(1, null, @resources)
 			@ResourceWriter.syncResourcesToDisk({
 				project_id: @project_id,
 				syncType: "incremental",


### PR DESCRIPTION
if request has an option incremental:<state-id> and the <state-id> matches the value from the last full compile, then write the content in the request incrementally into the compile directory.

if the request has an option state:<state-id> it is a full compile and the state id is written into the compile directory in the file .resource-state

if the state-id on an incremental compile doesn't match the value in the .resource-state file, return a response of 409 (Conflict).

Outstanding tasks:

- [x] Update OutputFileFinder logic
- [x] tests for RequestParser 
- [x] tests for ResourceWriter