### PR TITLE
lock compile directory

### DIFF
--- a/app/coffee/CompileController.coffee
+++ b/app/coffee/CompileController.coffee
@@ -17,7 +17,7 @@ module.exports = CompileController =
 				return next(error) if error?
 				CompileManager.doCompileWithLock request, (error, outputFiles = []) ->
 					if error instanceof Errors.AlreadyCompilingError
-						code = 423 # Http 443 Locked
+						code = 423 # Http 423 Locked
 						status = "compile-in-progress"
 					else if error instanceof Errors.FilesOutOfSyncError
 						code = 409 # Http 409 Conflict

--- a/app/coffee/Errors.coffee
+++ b/app/coffee/Errors.coffee
@@ -12,6 +12,14 @@ FilesOutOfSyncError = (message) ->
 	return error
 FilesOutOfSyncError.prototype.__proto__ = Error.prototype
 
+AlreadyCompilingError = (message) ->
+	error = new Error(message)
+	error.name = "AlreadyCompilingError"
+	error.__proto__ = AlreadyCompilingError.prototype
+	return error
+AlreadyCompilingError.prototype.__proto__ = Error.prototype
+
 module.exports = Errors =
 	NotFoundError: NotFoundError
 	FilesOutOfSyncError: FilesOutOfSyncError
+	AlreadyCompilingError: AlreadyCompilingError

--- a/app/coffee/LockManager.coffee
+++ b/app/coffee/LockManager.coffee
@@ -1,0 +1,23 @@
+Settings = require('settings-sharelatex')
+logger = require "logger-sharelatex"
+Lockfile = require('lockfile') # from https://github.com/npm/lockfile
+Errors = require "./Errors"
+
+module.exports = LockManager =
+	LOCK_TEST_INTERVAL: 1000 # 50ms between each test of the lock
+	MAX_LOCK_WAIT_TIME: 15000 # 10s maximum time to spend trying to get the lock
+	LOCK_STALE: 5*60*1000 # 5 mins time until lock auto expires
+
+	runWithLock: (path, runner = ((releaseLock = (error) ->) ->), callback = ((error) ->)) ->
+		lockOpts =
+			wait: @MAX_LOCK_WAIT_TIME
+			pollPeriod: @LOCK_TEST_INTERVAL
+			stale: @LOCK_STALE
+		Lockfile.lock path, lockOpts, (error) ->
+			return callback new Errors.AlreadyCompilingError("compile in progress")	if error?.code is 'EEXIST'
+			return callback(error) if error?
+			runner (error1, args...) ->
+				Lockfile.unlock path, (error2) ->
+					error = error1 or error2
+					return callback(error) if error?
+					callback(null, args...)

--- a/app/coffee/ResourceWriter.coffee
+++ b/app/coffee/ResourceWriter.coffee
@@ -78,7 +78,7 @@ module.exports = ResourceWriter =
 					should_delete = true
 					if path.match(/^output\./) or path.match(/\.aux$/) or path.match(/^cache\//) # knitr cache
 						should_delete = false
-					if path == '.project-sync-state'
+					if path == '.project-sync-state' or path == '.project-lock'
 						should_delete = false
 					if path == "output.pdf" or path == "output.dvi" or path == "output.log" or path == "output.xdv"
 						should_delete = true

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "fs-extra": "^0.16.3",
     "grunt-mkdir": "^1.0.0",
     "heapdump": "^0.3.5",
+    "lockfile": "^1.0.3",
     "logger-sharelatex": "git+https://github.com/sharelatex/logger-sharelatex.git#v1.5.4",
     "lynx": "0.0.11",
     "metrics-sharelatex": "git+https://github.com/sharelatex/metrics-sharelatex.git#v1.5.0",

--- a/test/unit/coffee/CompileControllerTests.coffee
+++ b/test/unit/coffee/CompileControllerTests.coffee
@@ -49,7 +49,7 @@ describe "CompileController", ->
 
 		describe "successfully", ->
 			beforeEach ->
-				@CompileManager.doCompile = sinon.stub().callsArgWith(1, null, @output_files)
+				@CompileManager.doCompileWithLock = sinon.stub().callsArgWith(1, null, @output_files)
 				@CompileController.compile @req, @res
 
 			it "should parse the request", ->
@@ -58,7 +58,7 @@ describe "CompileController", ->
 					.should.equal true
 
 			it "should run the compile for the specified project", ->
-				@CompileManager.doCompile
+				@CompileManager.doCompileWithLock
 					.calledWith(@request_with_project_id)
 					.should.equal true
 
@@ -84,7 +84,7 @@ describe "CompileController", ->
 			
 		describe "with an error", ->
 			beforeEach ->
-				@CompileManager.doCompile = sinon.stub().callsArgWith(1, new Error(@message = "error message"), null)
+				@CompileManager.doCompileWithLock = sinon.stub().callsArgWith(1, new Error(@message = "error message"), null)
 				@CompileController.compile @req, @res
 		
 			it "should return the JSON response with the error", ->
@@ -102,7 +102,7 @@ describe "CompileController", ->
 			beforeEach ->
 				@error = new Error(@message = "container timed out")
 				@error.timedout = true
-				@CompileManager.doCompile = sinon.stub().callsArgWith(1, @error, null)
+				@CompileManager.doCompileWithLock = sinon.stub().callsArgWith(1, @error, null)
 				@CompileController.compile @req, @res
 		
 			it "should return the JSON response with the timeout status", ->
@@ -118,7 +118,7 @@ describe "CompileController", ->
 
 		describe "when the request returns no output files", ->
 			beforeEach ->
-				@CompileManager.doCompile = sinon.stub().callsArgWith(1, null, [])
+				@CompileManager.doCompileWithLock = sinon.stub().callsArgWith(1, null, [])
 				@CompileController.compile @req, @res
 		
 			it "should return the JSON response with the failure status", ->

--- a/test/unit/coffee/CompileManagerTests.coffee
+++ b/test/unit/coffee/CompileManagerTests.coffee
@@ -21,6 +21,7 @@ describe "CompileManager", ->
 			"./TikzManager": @TikzManager = {}
 			"./LockManager": @LockManager = {}
 			"fs": @fs = {}
+			"fs-extra": @fse = { ensureDir: sinon.stub().callsArg(1) }
 		@callback = sinon.stub()
 
 	describe "doCompileWithLock", ->
@@ -30,6 +31,8 @@ describe "CompileManager", ->
 				project_id: @project_id = "project-id-123"
 				user_id: @user_id = "1234"
 			@output_files = ["foo", "bar"]
+			@Settings.compileDir = "compiles"
+			@compileDir = "#{@Settings.path.compilesDir}/#{@project_id}-#{@user_id}"
 			@CompileManager.doCompile = sinon.stub().callsArgWith(1, null, @output_files)
 			@LockManager.runWithLock = (lockFile, runner, callback) ->
 				runner (err, result...) ->
@@ -38,6 +41,10 @@ describe "CompileManager", ->
 		describe "when the project is not locked", ->
 			beforeEach ->
 				@CompileManager.doCompileWithLock @request, @callback
+
+			it "should ensure that the compile directory exists", ->
+				@fse.ensureDir.calledWith(@compileDir)
+				.should.equal true
 
 			it "should call doCompile with the request", ->
 				@CompileManager.doCompile
@@ -54,6 +61,10 @@ describe "CompileManager", ->
 				@LockManager.runWithLock = (lockFile, runner, callback) =>
 					callback(@error)
 				@CompileManager.doCompileWithLock @request, @callback
+
+			it "should ensure that the compile directory exists", ->
+				@fse.ensureDir.calledWith(@compileDir)
+				.should.equal true
 
 			it "should not call doCompile with the request", ->
 				@CompileManager.doCompile

--- a/test/unit/coffee/LockManager.coffee
+++ b/test/unit/coffee/LockManager.coffee
@@ -1,0 +1,54 @@
+SandboxedModule = require('sandboxed-module')
+sinon = require('sinon')
+require('chai').should()
+modulePath = require('path').join __dirname, '../../../app/js/LockManager'
+Path = require "path"
+Errors = require "../../../app/js/Errors"
+
+describe "LockManager", ->
+	beforeEach ->
+		@LockManager = SandboxedModule.require modulePath, requires:
+			"settings-sharelatex": {}
+			"logger-sharelatex": @logger = { log: sinon.stub(), error: sinon.stub() }
+			"lockfile": @Lockfile = {}
+		@lockFile = "/local/compile/directory/.project-lock"
+
+	describe "runWithLock", ->
+		beforeEach ->
+			@runner = sinon.stub().callsArgWith(0, null, "foo", "bar")
+			@callback = sinon.stub()
+
+		describe "normally", ->
+			beforeEach ->
+				@Lockfile.lock = sinon.stub().callsArgWith(2, null)
+				@Lockfile.unlock = sinon.stub().callsArgWith(1, null)
+				@LockManager.runWithLock @lockFile, @runner, @callback
+
+			it "should run the compile", ->
+				@runner
+					.calledWith()
+					.should.equal true
+
+			it "should call the callback with the response from the compile", ->
+				@callback
+					.calledWithExactly(null, "foo", "bar")
+					.should.equal true
+
+		describe "when the project is locked", ->
+			beforeEach ->
+				@error = new Error()
+				@error.code =  "EEXIST"
+				@Lockfile.lock = sinon.stub().callsArgWith(2,@error)
+				@Lockfile.unlock = sinon.stub().callsArgWith(1, null)
+				@LockManager.runWithLock @lockFile, @runner, @callback
+
+			it "should not run the compile", ->
+				@runner
+					.called
+					.should.equal false
+
+			it "should return an error", ->
+				error = new Errors.AlreadyCompilingError()
+				@callback
+					.calledWithExactly(error)
+					.should.equal true


### PR DESCRIPTION
prevent two compiles from trying to run at the same time and clobbering the files in the compile directory.