### PR TITLE
fix tikzexternalize

### DIFF
--- a/app/coffee/CompileManager.coffee
+++ b/app/coffee/CompileManager.coffee
@@ -62,10 +62,7 @@ module.exports = CompileManager =
 					callback()
 
 			createTikzFileIfRequired = (callback) ->
-				if TikzManager.needsOutputFile(request.rootResourcePath, resourceList)
-					TikzManager.injectOutputFile compileDir, request.rootResourcePath, callback
-				else
-					callback()
+				TikzManager.createTikzFileIfRequired compileDir, request.rootResourcePath, resourceList, callback
 
 			# set up environment variables for chktex
 			env = {}

--- a/app/coffee/ResourceWriter.coffee
+++ b/app/coffee/ResourceWriter.coffee
@@ -24,7 +24,9 @@ module.exports = ResourceWriter =
 						return callback(error) if error?
 						ResourceWriter.saveIncrementalResourcesToDisk request.project_id, request.resources, basePath, (error) ->
 							return callback(error) if error?
-							callback(null, resourceList)
+							ResourceWriter.includeResourceContent request.resources, resourceList, (error, resources) ->
+								return callback(error) if error?
+								callback(null, resources)
 		else
 			logger.log project_id: request.project_id, user_id: request.user_id, "full sync"
 			@saveAllResourcesToDisk request.project_id, request.resources, basePath, (error) ->
@@ -128,3 +130,10 @@ module.exports = ResourceWriter =
 			return callback new Error("resource path is outside root directory")
 		else
 			return callback(null, path)
+
+	includeResourceContent: (requestResources = [], cachedResources = [], callback = (error, resources) ->) ->
+		inRequest = {}
+		for resource in requestResources
+			inRequest[resource.path] = true
+		cachedResources = (resource for resource in cachedResources when !inRequest[resource.path])
+		callback null, [requestResources..., cachedResources...]

--- a/app/coffee/ResourceWriter.coffee
+++ b/app/coffee/ResourceWriter.coffee
@@ -78,6 +78,8 @@ module.exports = ResourceWriter =
 					should_delete = true
 					if path.match(/^output\./) or path.match(/\.aux$/) or path.match(/^cache\//) # knitr cache
 						should_delete = false
+					if path.match(/^output-.*/) # Tikz cached figures
+						should_delete = false
 					if path == "output.pdf" or path == "output.dvi" or path == "output.log" or path == "output.xdv"
 						should_delete = true
 					if path == "output.tex" # created by TikzManager if present in output files

--- a/app/coffee/TikzManager.coffee
+++ b/app/coffee/TikzManager.coffee
@@ -1,6 +1,7 @@
 fs = require "fs"
 Path = require "path"
 ResourceWriter = require "./ResourceWriter"
+SafeReader = require "./SafeReader"
 logger = require "logger-sharelatex"
 
 # for \tikzexternalize to work the main file needs to match the
@@ -8,6 +9,34 @@ logger = require "logger-sharelatex"
 # copy of the main file as 'output.tex'.
 
 module.exports = TikzManager =
+
+	createTikzFileIfRequired: (compileDir, rootResourcePath, resources, callback = (err)->) ->
+		# first see if we need to create an output.tex file
+		needsOutputFile = TikzManager.needsOutputFile(rootResourcePath, resources)
+		if needsOutputFile is "missing"
+			# it's an incremental compile, and the file content has not been
+			# sent in the request, so we need to look at the existing
+			# content on disk and retry.
+			TikzManager.loadRootResource compileDir, rootResourcePath, (err, rootResource) ->
+				return callback(err) if err?
+				TikzManager.createTikzFileIfRequired compileDir, rootResourcePath, [rootResource], callback
+		else
+			# if we get here, we have examined the main file and know whether
+			# it contains \tikzexternalize or not.
+			if needsOutputFile
+				TikzManager.injectOutputFile compileDir, rootResourcePath, callback
+			else
+				return callback()
+
+	loadRootResource: (compileDir, rootResourcePath, callback = (err)->) ->
+		ResourceWriter.checkPath compileDir, rootResourcePath, (error, path) ->
+			return callback(error) if error?
+			# read the first 64KB of the main file
+			SafeReader.readFile path, 65536, "utf8", (err, content) ->
+				return callback(err) if err?
+				rootResource = {path: rootResourcePath, content: content}
+				callback(null, rootResource)
+
 	needsOutputFile: (rootResourcePath, resources) ->
 		# if there's already an output.tex file, we don't want to touch it
 		for resource in resources
@@ -23,7 +52,9 @@ module.exports = TikzManager =
 	_includesTikz: (resource) ->
 		# check if we are using tikz externalize
 		content = resource.content?.slice(0,65536)
-		if content?.indexOf("\\tikzexternalize") >= 0
+		if !content? # resource has no content in incremental compile
+			return "missing"
+		else if content?.indexOf("\\tikzexternalize") >= 0
 			return true
 		else
 			return false

--- a/test/unit/coffee/CompileManagerTests.coffee
+++ b/test/unit/coffee/CompileManagerTests.coffee
@@ -108,8 +108,8 @@ describe "CompileManager", ->
 			@OutputFileFinder.findOutputFiles = sinon.stub().callsArgWith(2, null, @output_files)
 			@OutputCacheManager.saveOutputFiles = sinon.stub().callsArgWith(2, null, @build_files)
 			@DraftModeManager.injectDraftMode = sinon.stub().callsArg(1)
-			@TikzManager.needsOutputFile = sinon.stub().returns(false)
-		
+			@TikzManager.createTikzFileIfRequired = sinon.stub().callsArg(3)
+
 		describe "normally", ->
 			beforeEach ->
 				@CompileManager.doCompile @request, @callback

--- a/test/unit/coffee/TikzManager.coffee
+++ b/test/unit/coffee/TikzManager.coffee
@@ -7,8 +7,102 @@ describe 'TikzManager', ->
 	beforeEach ->
 		@TikzManager = SandboxedModule.require modulePath, requires:
 			"./ResourceWriter": @ResourceWriter = {}
+			"./SafeReader": @SafeReader = {}
 			"fs": @fs = {}
 			"logger-sharelatex": @logger = {log: () ->}
+		@callback = sinon.stub()
+
+	describe "createTikzFileIfRequired", ->
+		beforeEach ->
+				@compileDir = "compile-dir"
+				@rootResourcePath = "main.tex"
+				@resources = [{path:"main.tex", content:"hello"}]
+				@TikzManager.injectOutputFile = sinon.stub().callsArg(2)
+
+		describe "when the output file is needed", ->
+			beforeEach ->
+				@TikzManager.needsOutputFile = sinon.stub().returns true
+				@TikzManager.createTikzFileIfRequired @compileDir, @rootResourcePath, @resources, @callback
+
+			it "should check if the output file is needed", ->
+				@TikzManager.needsOutputFile
+				.called.should.equal true
+
+			it "should  inject the output file", ->
+				@TikzManager.injectOutputFile
+				.calledWith(@compileDir, @rootResourcePath, @callback)
+				.should.equal true
+
+			it "should call the callback", ->
+				@callback.called
+				.should.equal true
+
+		describe "when the output file is not needed", ->
+			beforeEach ->
+				@TikzManager.needsOutputFile = sinon.stub().returns false
+				@TikzManager.createTikzFileIfRequired @compileDir, @rootResourcePath, @resources, @callback
+
+			it "should check if the output file is needed", ->
+				@TikzManager.needsOutputFile
+				.called.should.equal true
+
+			it "should not inject the output file", ->
+				@TikzManager.injectOutputFile
+				.called
+				.should.equal false
+
+			it "should call the callback", ->
+				@callback.called
+				.should.equal true
+
+		describe "when the output file is missing", ->
+			beforeEach ->
+				@resources = [{path:"main.tex"}]
+				@ResourceWriter.checkPath = sinon.stub()
+					.withArgs(@compileDir, @rootResourcePath)
+					.callsArgWith(2, null, "#{@compileDir}/#{@rootResourcePath}")
+
+			describe "and the file on disk does not contain \\tikzexternalize", ->
+				beforeEach ->
+					@SafeReader.readFile = sinon.stub()
+						.withArgs("#{@compileDir}/#{@rootResourcePath}")
+						.callsArgWith(3, null, "hello")
+					@TikzManager.createTikzFileIfRequired @compileDir, @rootResourcePath, @resources, @callback
+
+				it "should look at the file on disk", ->
+					@SafeReader.readFile
+					.calledWith("#{@compileDir}/#{@rootResourcePath}")
+					.should.equal true
+
+				it "should not inject the output file", ->
+					@TikzManager.injectOutputFile
+					.called
+					.should.equal false
+
+				it "should call the callback", ->
+					@callback.called
+					.should.equal true
+
+			describe "and the file on disk does contain \\tikzexternalize", ->
+				beforeEach ->
+					@SafeReader.readFile = sinon.stub()
+						.withArgs("#{@compileDir}/#{@rootResourcePath}")
+						.callsArgWith(3, null, "hello \\tikzexternalize")
+					@TikzManager.createTikzFileIfRequired @compileDir, @rootResourcePath, @resources, @callback
+
+				it "should look at the file on disk", ->
+					@SafeReader.readFile
+					.calledWith("#{@compileDir}/#{@rootResourcePath}")
+					.should.equal true
+
+				it "should inject the output file", ->
+					@TikzManager.injectOutputFile
+					.called
+					.should.equal true
+
+				it "should call the callback", ->
+					@callback.called
+					.should.equal true
 
 	describe "needsOutputFile", ->
 		it "should return true if there is a \\tikzexternalize", ->
@@ -30,11 +124,11 @@ describe 'TikzManager', ->
 				{ path: 'output.tex' }
 			]).should.equal false
 
-		it "should return false if the file has no content", ->
+		it "should return 'missing' if the file has no content (incremental compile)", ->
 			@TikzManager.needsOutputFile("main.tex", [
 				{ path: 'foo.tex' },
 				{ path: 'main.tex' }
-			]).should.equal false
+			]).should.equal "missing"
 
 	describe "injectOutputFile", ->
 		beforeEach ->


### PR DESCRIPTION
tikzexternalize is broken on incremental compiles because we aren't doing (2).  It isn't caching properly on normal compiles because we are removing some of the cache files (1)

1. we need to keep the tikzexternalize cached files
2. on incremental compiles, to check for tikzexternalize we need to look at the root file content, either from the request or from disk