### PR TITLE
fix tikzexternalize ii

### DIFF
--- a/app/coffee/CompileManager.coffee
+++ b/app/coffee/CompileManager.coffee
@@ -62,10 +62,12 @@ module.exports = CompileManager =
 					callback()
 
 			createTikzFileIfRequired = (callback) ->
-				if TikzManager.needsOutputFile(request.rootResourcePath, resourceList)
-					TikzManager.injectOutputFile compileDir, request.rootResourcePath, callback
-				else
-					callback()
+				TikzManager.checkMainFile compileDir, request.rootResourcePath, resourceList, (error, usesTikzExternalize) ->
+					return callback(error) if error?
+					if usesTikzExternalize
+						TikzManager.injectOutputFile compileDir, request.rootResourcePath, callback
+					else
+						callback()
 
 			# set up environment variables for chktex
 			env = {}

--- a/app/coffee/ResourceWriter.coffee
+++ b/app/coffee/ResourceWriter.coffee
@@ -78,6 +78,8 @@ module.exports = ResourceWriter =
 					should_delete = true
 					if path.match(/^output\./) or path.match(/\.aux$/) or path.match(/^cache\//) # knitr cache
 						should_delete = false
+					if path.match(/^output-.*/) # Tikz cached figures
+						should_delete = false
 					if path == "output.pdf" or path == "output.dvi" or path == "output.log" or path == "output.xdv"
 						should_delete = true
 					if path == "output.tex" # created by TikzManager if present in output files

--- a/app/coffee/TikzManager.coffee
+++ b/app/coffee/TikzManager.coffee
@@ -1,6 +1,7 @@
 fs = require "fs"
 Path = require "path"
 ResourceWriter = require "./ResourceWriter"
+SafeReader = require "./SafeReader"
 logger = require "logger-sharelatex"
 
 # for \tikzexternalize to work the main file needs to match the
@@ -8,25 +9,21 @@ logger = require "logger-sharelatex"
 # copy of the main file as 'output.tex'.
 
 module.exports = TikzManager =
-	needsOutputFile: (rootResourcePath, resources) ->
+
+	checkMainFile: (compileDir, mainFile, resources, callback = (error, usesTikzExternalize) ->) ->
 		# if there's already an output.tex file, we don't want to touch it
 		for resource in resources
 			if resource.path is "output.tex"
-				return false
+				logger.log compileDir: compileDir, mainFile: mainFile, "output.tex already in resources"
+				return callback(null, false)
 		# if there's no output.tex, see if we are using tikz/pgf in the main file
-		for resource in resources
-			if resource.path is rootResourcePath
-				return TikzManager._includesTikz (resource)
-		# otherwise false
-		return false
-
-	_includesTikz: (resource) ->
-		# check if we are using tikz externalize
-		content = resource.content?.slice(0,65536)
-		if content?.indexOf("\\tikzexternalize") >= 0
-			return true
-		else
-			return false
+		ResourceWriter.checkPath compileDir, mainFile, (error, path) ->
+			return callback(error) if error?
+			SafeReader.readFile path, 65536, "utf8", (error, content) ->
+				return callback(error) if error?
+				usesTikzExternalize = content?.indexOf("\\tikzexternalize") >= 0
+				logger.log compileDir: compileDir, mainFile: mainFile, usesTikzExternalize:usesTikzExternalize, "checked for tikzexternalize"
+				callback null, usesTikzExternalize
 
 	injectOutputFile: (compileDir, mainFile, callback = (error) ->) ->
 		ResourceWriter.checkPath compileDir, mainFile, (error, path) ->

--- a/test/unit/coffee/CompileManagerTests.coffee
+++ b/test/unit/coffee/CompileManagerTests.coffee
@@ -108,7 +108,7 @@ describe "CompileManager", ->
 			@OutputFileFinder.findOutputFiles = sinon.stub().callsArgWith(2, null, @output_files)
 			@OutputCacheManager.saveOutputFiles = sinon.stub().callsArgWith(2, null, @build_files)
 			@DraftModeManager.injectDraftMode = sinon.stub().callsArg(1)
-			@TikzManager.needsOutputFile = sinon.stub().returns(false)
+			@TikzManager.checkMainFile = sinon.stub().callsArg(3, false)
 		
 		describe "normally", ->
 			beforeEach ->


### PR DESCRIPTION
1. keep tikz cached files
2. simplify tikzexternalize checks so they work with incremental compiles (always look at file on disk)

Now that we have full and incremental compiles to deal with, it's simpler if we just open the main file on disk every time and look at the content to see if tikzexternalize is used. 

I originally wrote this pull request to extend the existing check - i.e. look at the content in the incoming request first and then check the file on disk if the main file wasn't in the request, but that was overly complicated optimisation -- when we do the tex run itself it will open 10's or hundreds of files, so saving one file open in the node process isn't worth the complexity. 