### PR TITLE
fix read logging

### DIFF
--- a/app/coffee/SafeReader.coffee
+++ b/app/coffee/SafeReader.coffee
@@ -12,16 +12,14 @@ module.exports = SafeReader =
 			return callback(err) if err?
 
 			# safely return always closing the file
-			callbackWithClose = (err, result) ->
+			callbackWithClose = (err, result...) ->
 				fs.close fd, (err1) ->
 					return callback(err) if err?
 					return callback(err1) if err1?
-					callback(null, result)
+					callback(null, result...)
 
 			buff = new Buffer(size, 0) # fill with zeros
 			fs.read fd, buff, 0, buff.length, 0, (err, bytesRead, buffer) ->
 				return callbackWithClose(err) if err?
 				result = buffer.toString(encoding, 0, bytesRead)
-				if bytesRead is size
-					logger.error file:file, size:size, bytesRead:bytesRead, "file truncated"
-				callbackWithClose(null, result)
+				callbackWithClose(null, result, bytesRead)

--- a/app/coffee/TikzManager.coffee
+++ b/app/coffee/TikzManager.coffee
@@ -30,6 +30,6 @@ module.exports = TikzManager =
 			return callback(error) if error?
 			fs.readFile path, "utf8", (error, content) ->
 				return callback(error) if error?
-				logger.log compileDir: compileDir, mainFile: mainFile, "copied file to ouput.tex for tikz"
+				logger.log compileDir: compileDir, mainFile: mainFile, "copied file to output.tex for tikz"
 				# use wx flag to ensure that output file does not already exist
 				fs.writeFile Path.join(compileDir, "output.tex"), content, {flag:'wx'}, callback


### PR DESCRIPTION
we are logging end-of-file errors in the file reader, change it to let the caller decide when to do it

TikzManager is using it to look at the header of the file, it passes a small number of bytes to read -- when we read all of those it is triggering and end-of-file message in sentry.