### PR TITLE
log an error if core file is found in output

### DIFF
--- a/app/coffee/CompileController.coffee
+++ b/app/coffee/CompileController.coffee
@@ -39,6 +39,10 @@ module.exports = CompileController =
 						for file in outputFiles
 							if file.path?.match(/output\.pdf$/)
 								status = "success"
+						# log an error if any core files are found
+						for file in outputFiles
+							if file.path is "core"
+								logger.error project_id:request.project_id, req:req, outputFiles:outputFiles, "core file found in output"
 
 					timer.done()
 					res.status(code or 200).send {


### PR DESCRIPTION
if the compilation produces a core file, log it as an error.