### PR TITLE
Provide hosts as settings and add npm run start script

### DIFF
--- a/config/settings.defaults.coffee
+++ b/config/settings.defaults.coffee
@@ -16,21 +16,10 @@ module.exports =
 		clsiCacheDir: Path.resolve(__dirname + "/../cache")
 		synctexBaseDir: (project_id) -> Path.join(@compilesDir, project_id)
 
-#	clsi:
-#		commandRunner: "docker-runner-sharelatex"
-#		docker:
-#			image: "quay.io/sharelatex/texlive-full:2017.1"
-#			env:
-#				HOME: "/tmp"
-#			socketPath: "/var/run/docker.sock"
-#			user: "tex"
-#		expireProjectAfterIdleMs: 24 * 60 * 60 * 1000
-#		checkProjectsIntervalMs: 10 * 60 * 1000
-
 	internal:
 		clsi:
 			port: 3013
-			host: "localhost"
+			host: process.env["LISTEN_ADDRESS"] or "localhost"
 
 	
 	apis:
@@ -40,3 +29,16 @@ module.exports =
 	smokeTest: false
 	project_cache_length_ms: 1000 * 60 * 60 * 24
 	parallelFileDownloads:1
+
+if process.env["COMMAND_RUNNER"]
+	module.exports.clsi =
+		commandRunner: process.env["COMMAND_RUNNER"]
+		docker:
+			image: process.env["TEXLIVE_IMAGE"] or "quay.io/sharelatex/texlive-full:2017.1"
+			env:
+				HOME: "/tmp"
+			socketPath: "/var/run/docker.sock"
+			user: "tex"
+		expireProjectAfterIdleMs: 24 * 60 * 60 * 1000
+		checkProjectsIntervalMs: 10 * 60 * 1000
+	module.exports.path.sandboxedCompilesHostDir = process.env["COMPILES_HOST_DIR"]

--- a/config/settings.defaults.coffee
+++ b/config/settings.defaults.coffee
@@ -38,7 +38,7 @@ if process.env["COMMAND_RUNNER"]
 			env:
 				HOME: "/tmp"
 			socketPath: "/var/run/docker.sock"
-			user: "tex"
+			user: process.env["TEXLIVE_IMAGE_USER"] or "tex"
 		expireProjectAfterIdleMs: 24 * 60 * 60 * 1000
 		checkProjectsIntervalMs: 10 * 60 * 1000
 	module.exports.path.sandboxedCompilesHostDir = process.env["COMPILES_HOST_DIR"]

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
     "type": "git",
     "url": "https://github.com/sharelatex/clsi-sharelatex.git"
   },
+  "scripts": {
+    "compile:app": "coffee -o app/js -c app/coffee && coffee -c app.coffee",
+    "start": "npm run compile:app && node app.js"
+  },
   "author": "James Allen <james@sharelatex.com>",
   "dependencies": {
     "async": "0.2.9",


### PR DESCRIPTION
Makes this service compatible with https://github.com/sharelatex/sharelatex-dev-environment

Allows other service's locations to be passed in via environment variables which are provided by docker-compose. Also allows our docker-command-runner to be configured via environment variables.

Also provides an `npm run start` script as a common entry point to all services via docker-compose.