### PR TITLE
increase timeout on wordcount

### DIFF
--- a/app/coffee/CompileManager.coffee
+++ b/app/coffee/CompileManager.coffee
@@ -281,7 +281,7 @@ module.exports = CompileManager =
 		file_path = "$COMPILE_DIR/" + file_name
 		command = [ "texcount", '-nocol', '-inc', file_path, "-out=" + file_path + ".wc"]
 		directory = getCompileDir(project_id, user_id)
-		timeout = 10 * 1000
+		timeout = 60 * 1000 # increased to allow for large projects
 		compileName = getCompileName(project_id, user_id)
 
 		CommandRunner.run compileName, command, directory, image, timeout, {}, (error) ->

--- a/test/unit/coffee/CompileManagerTests.coffee
+++ b/test/unit/coffee/CompileManagerTests.coffee
@@ -298,7 +298,7 @@ describe "CompileManager", ->
 			@callback  = sinon.stub()
 
 			@project_id = "project-id-123"
-			@timeout = 10 * 1000
+			@timeout = 60 * 1000
 			@file_name = "main.tex"
 			@Settings.path.compilesDir = "/local/compile/directory"
 			@image = "example.com/image"


### PR DESCRIPTION
Increase the timeout on wordcount to 1 minute as a legitimate project was hitting the 10 second timeout limit.

Fixes https://github.com/overleaf/sharelatex/issues/630