### PR TITLE
cache pdf files generated by epstopdf

### DIFF
--- a/app/coffee/ResourceWriter.coffee
+++ b/app/coffee/ResourceWriter.coffee
@@ -80,6 +80,8 @@ module.exports = ResourceWriter =
 						should_delete = false
 					if path.match(/^output-.*/) # Tikz cached figures
 						should_delete = false
+					if path.match(/-eps-converted-to\.pdf$/) # Epstopdf generated files
+						should_delete = false 
 					if path == "output.pdf" or path == "output.dvi" or path == "output.log" or path == "output.xdv"
 						should_delete = true
 					if path == "output.tex" # created by TikzManager if present in output files

--- a/test/unit/coffee/ResourceWriterTests.coffee
+++ b/test/unit/coffee/ResourceWriterTests.coffee
@@ -134,6 +134,9 @@ describe "ResourceWriter", ->
 				type: "aux"
 			}, {
 				path: "cache/_chunk1"
+			},{
+				path: "figures/image-eps-converted-to.pdf"
+				type: "pdf"
 			}]
 			@resources = "mock-resources"
 			@OutputFileFinder.findOutputFiles = sinon.stub().callsArgWith(2, null, @output_files)
@@ -163,6 +166,11 @@ describe "ResourceWriter", ->
 		it "should not delete the knitr cache file", ->
 			@ResourceWriter._deleteFileIfNotDirectory
 				.calledWith(path.join(@basePath, "cache/_chunk1"))
+				.should.equal false
+
+		it "should not delete the epstopdf converted files", ->
+			@ResourceWriter._deleteFileIfNotDirectory
+				.calledWith(path.join(@basePath, "figures/image-eps-converted-to.pdf"))
 				.should.equal false
 
 		it "should call the callback", ->


### PR DESCRIPTION
We are not caching files produced by epstopdf, which is slowing down compiles.  (I thought we used to do this!)

This excludes the generated files `...-eps-converted-to.pdf` from the `epstopdf` package.

Connects to https://github.com/overleaf/sharelatex/issues/877