### PR TITLE
use TikzManager to create main file for pstool package

### DIFF
--- a/app/coffee/CompileManager.coffee
+++ b/app/coffee/CompileManager.coffee
@@ -58,9 +58,9 @@ module.exports = CompileManager =
 					callback()
 
 			createTikzFileIfRequired = (callback) ->
-				TikzManager.checkMainFile compileDir, request.rootResourcePath, resourceList, (error, usesTikzExternalize) ->
+				TikzManager.checkMainFile compileDir, request.rootResourcePath, resourceList, (error, needsMainFile) ->
 					return callback(error) if error?
-					if usesTikzExternalize
+					if needsMainFile
 						TikzManager.injectOutputFile compileDir, request.rootResourcePath, callback
 					else
 						callback()

--- a/app/coffee/TikzManager.coffee
+++ b/app/coffee/TikzManager.coffee
@@ -4,26 +4,28 @@ ResourceWriter = require "./ResourceWriter"
 SafeReader = require "./SafeReader"
 logger = require "logger-sharelatex"
 
-# for \tikzexternalize to work the main file needs to match the
+# for \tikzexternalize or pstool to work the main file needs to match the
 # jobname.  Since we set the -jobname to output, we have to create a
 # copy of the main file as 'output.tex'.
 
 module.exports = TikzManager =
 
-	checkMainFile: (compileDir, mainFile, resources, callback = (error, usesTikzExternalize) ->) ->
+	checkMainFile: (compileDir, mainFile, resources, callback = (error, needsMainFile) ->) ->
 		# if there's already an output.tex file, we don't want to touch it
 		for resource in resources
 			if resource.path is "output.tex"
 				logger.log compileDir: compileDir, mainFile: mainFile, "output.tex already in resources"
 				return callback(null, false)
-		# if there's no output.tex, see if we are using tikz/pgf in the main file
+		# if there's no output.tex, see if we are using tikz/pgf or pstool in the main file
 		ResourceWriter.checkPath compileDir, mainFile, (error, path) ->
 			return callback(error) if error?
 			SafeReader.readFile path, 65536, "utf8", (error, content) ->
 				return callback(error) if error?
 				usesTikzExternalize = content?.indexOf("\\tikzexternalize") >= 0
-				logger.log compileDir: compileDir, mainFile: mainFile, usesTikzExternalize:usesTikzExternalize, "checked for tikzexternalize"
-				callback null, usesTikzExternalize
+				usesPsTool = content.indexOf("{pstool}") >= 0
+				logger.log compileDir: compileDir, mainFile: mainFile, usesTikzExternalize:usesTikzExternalize, usesPsTool: usesPsTool, "checked for packages needing main file as output.tex"
+				needsMainFile = (usesTikzExternalize || usesPsTool)
+				callback null, needsMainFile
 
 	injectOutputFile: (compileDir, mainFile, callback = (error) ->) ->
 		ResourceWriter.checkPath compileDir, mainFile, (error, path) ->

--- a/app/coffee/TikzManager.coffee
+++ b/app/coffee/TikzManager.coffee
@@ -22,7 +22,7 @@ module.exports = TikzManager =
 			SafeReader.readFile path, 65536, "utf8", (error, content) ->
 				return callback(error) if error?
 				usesTikzExternalize = content?.indexOf("\\tikzexternalize") >= 0
-				usesPsTool = content.indexOf("{pstool}") >= 0
+				usesPsTool = content?.indexOf("{pstool}") >= 0
 				logger.log compileDir: compileDir, mainFile: mainFile, usesTikzExternalize:usesTikzExternalize, usesPsTool: usesPsTool, "checked for packages needing main file as output.tex"
 				needsMainFile = (usesTikzExternalize || usesPsTool)
 				callback null, needsMainFile

--- a/app/coffee/TikzManager.coffee
+++ b/app/coffee/TikzManager.coffee
@@ -32,6 +32,6 @@ module.exports = TikzManager =
 			return callback(error) if error?
 			fs.readFile path, "utf8", (error, content) ->
 				return callback(error) if error?
-				logger.log compileDir: compileDir, mainFile: mainFile, "copied file to output.tex for tikz"
+				logger.log compileDir: compileDir, mainFile: mainFile, "copied file to output.tex as project uses packages which require it"
 				# use wx flag to ensure that output file does not already exist
 				fs.writeFile Path.join(compileDir, "output.tex"), content, {flag:'wx'}, callback

--- a/test/unit/coffee/TikzManager.coffee
+++ b/test/unit/coffee/TikzManager.coffee
@@ -65,6 +65,22 @@ describe 'TikzManager', ->
 					@callback.calledWithExactly(null, false)
 					.should.equal true
 
+			describe "and the main file contains \\usepackage{pstool}", ->
+				beforeEach ->
+					@SafeReader.readFile = sinon.stub()
+						.withArgs("#{@compileDir}/#{@mainFile}")
+						.callsArgWith(3, null, "hello \\usepackage[random-options]{pstool}")
+					@TikzManager.checkMainFile @compileDir, @mainFile, @resources, @callback
+
+				it "should look at the file on disk", ->
+					@SafeReader.readFile
+					.calledWith("#{@compileDir}/#{@mainFile}")
+					.should.equal true
+
+				it "should call the callback with true ", ->
+					@callback.calledWithExactly(null, true)
+					.should.equal true
+
 	describe "injectOutputFile", ->
 		beforeEach ->
 			@rootDir = "/mock"


### PR DESCRIPTION
Copy the main file to `output.tex` when using the `pstool` package because it only works when `filename === jobname`.

Connects to https://github.com/overleaf/sharelatex/issues/832