### PR TITLE
Expand CLSI to Common LaTeX Service Interface on first use

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A web api for compiling LaTeX documents in the cloud
 
 [![Build Status](https://travis-ci.org/sharelatex/clsi-sharelatex.png?branch=master)](https://travis-ci.org/sharelatex/clsi-sharelatex)
 
-The CLSI provide a RESTful interface to traditional LaTeX tools (or, more generally, any command line tool for composing marked-up documents into a display format such as PDF or HTML). The CLSI listens on the following ports by default:
+The Common LaTeX Service Interface (CLSI) provides a RESTful interface to traditional LaTeX tools (or, more generally, any command line tool for composing marked-up documents into a display format such as PDF or HTML). The CLSI listens on the following ports by default:
 
 * TCP/3009 - the RESTful interface
 * TCP/3048 - reports load information


### PR DESCRIPTION
Define CLSI as "Common LaTeX Service Interface" on first use in README, as I always forget what it stands for.