### PR TITLE
add epoll_pwait to secomp profile

### DIFF
--- a/seccomp/clsi-profile.json
+++ b/seccomp/clsi-profile.json
@@ -827,6 +827,10 @@
           "name": "gettimeofday",
           "action": "SCMP_ACT_ALLOW",
           "args": []
+        }, {
+          "name": "epoll_pwait",
+          "action": "SCMP_ACT_ALLOW",
+          "args": []
         }
     ]
 }


### PR DESCRIPTION
Last year golang changed from epoll_wait to epoll_pwait https://github.com/golang/go/issues/23750

This causes golang panic errors on mac when running secomp secure compiles using docker 18.09.1. It may start to become a problem on the clsi's where we are running on 17.03.2-ce in production.


