### PR TITLE
use explicit json content-type to avoid security issues with text/html

### DIFF
--- a/app/coffee/CompileController.coffee
+++ b/app/coffee/CompileController.coffee
@@ -84,7 +84,7 @@ module.exports = CompileController =
 		user_id = req.params.user_id
 		CompileManager.syncFromCode project_id, user_id, file, line, column, (error, pdfPositions) ->
 			return next(error) if error?
-			res.send JSON.stringify {
+			res.json {
 				pdf: pdfPositions
 			}
 
@@ -96,7 +96,7 @@ module.exports = CompileController =
 		user_id = req.params.user_id
 		CompileManager.syncFromPdf project_id, user_id, page, h, v, (error, codePositions) ->
 			return next(error) if error?
-			res.send JSON.stringify {
+			res.json {
 				code: codePositions
 			}
 
@@ -109,7 +109,7 @@ module.exports = CompileController =
 
 		CompileManager.wordcount project_id, user_id, file, image, (error, result) ->
 			return next(error) if error?
-			res.send JSON.stringify {
+			res.json {
 				texcount: result
 			}
 

--- a/test/unit/coffee/CompileControllerTests.coffee
+++ b/test/unit/coffee/CompileControllerTests.coffee
@@ -144,7 +144,7 @@ describe "CompileController", ->
 				file: @file
 				line: @line.toString()
 				column: @column.toString()
-			@res.send = sinon.stub()
+			@res.json = sinon.stub()
 
 			@CompileManager.syncFromCode = sinon.stub().callsArgWith(5, null, @pdfPositions = ["mock-positions"])
 			@CompileController.syncFromCode @req, @res, @next
@@ -155,8 +155,8 @@ describe "CompileController", ->
 				.should.equal true
 
 		it "should return the positions", ->
-			@res.send
-				.calledWith(JSON.stringify
+			@res.json
+				.calledWith(
 					pdf: @pdfPositions
 				)
 				.should.equal true
@@ -173,7 +173,7 @@ describe "CompileController", ->
 				page: @page.toString()
 				h: @h.toString()
 				v: @v.toString()
-			@res.send = sinon.stub()
+			@res.json = sinon.stub()
 
 			@CompileManager.syncFromPdf = sinon.stub().callsArgWith(5, null, @codePositions = ["mock-positions"])
 			@CompileController.syncFromPdf @req, @res, @next
@@ -184,8 +184,8 @@ describe "CompileController", ->
 				.should.equal true
 
 		it "should return the positions", ->
-			@res.send
-				.calledWith(JSON.stringify
+			@res.json
+				.calledWith(
 					code: @codePositions
 				)
 				.should.equal true
@@ -199,7 +199,7 @@ describe "CompileController", ->
 			@req.query =
 				file: @file
 				image: @image = "example.com/image"
-			@res.send = sinon.stub()
+			@res.json = sinon.stub()
 
 			@CompileManager.wordcount = sinon.stub().callsArgWith(4, null, @texcount = ["mock-texcount"])
 			@CompileController.wordcount @req, @res, @next
@@ -210,8 +210,8 @@ describe "CompileController", ->
 				.should.equal true
 
 		it "should return the texcount info", ->
-			@res.send
-				.calledWith(JSON.stringify
+			@res.json
+				.calledWith(
 					texcount: @texcount
 				)
 				.should.equal true


### PR DESCRIPTION
<!-- Please review https://github.com/overleaf/write_latex/blob/master/.github/CONTRIBUTING.md for guidance on what is expected in each section. -->

### Description

Same issue and fix as https://github.com/sharelatex/project-history-sharelatex/pull/267 but for clsi.  Affects synctex and wordcount.  I don't think these allow arbitrary output but fixing them anway. 

#### Screenshots

NA

#### Related Issues / PRs

Connects to https://github.com/overleaf/sharelatex/issues/1517

### Review

Same changes as before

#### Potential Impact



#### Manual Testing Performed

- [x] Unit tests


#### Accessibility

NA

### Deployment

NA

#### Deployment Checklist

- [ ]  Check synctex and word count.

#### Metrics and Monitoring

NA

#### Who Needs to Know?

@jdleesmiller @jpallen 